### PR TITLE
Update avoid-document-write-innerhtml.yaml

### DIFF
--- a/avoid-document-write-innerhtml.yaml
+++ b/avoid-document-write-innerhtml.yaml
@@ -10,10 +10,14 @@ file:
   - extensions:
       - js
 
+    matchers-condition: and
     matchers:
       - type: regex
         regex:
-          - "(document\\.write|innerHTML)"
+          - "document\\.write"
+      - type: regex  
+        regex:
+          - "innerHTML"
 
     extractors:
       - type: regex
@@ -21,4 +25,3 @@ file:
         name: extracted_script
         regex:
           - "(document\\.write|innerHTML)"
-


### PR DESCRIPTION
Changes: 

- Use `matchers-condition: and` to require both document.write and innerHTML matches
- Split the document.write and innerHTML regexes into separate matchers
- The extractors stay the same to extract any usage of either

This makes the template more targeted by requiring both risky functions to be present before triggering a match.