### PR TITLE
Update avoid-http-usage.yaml

### DIFF
--- a/avoid-http-usage.yaml
+++ b/avoid-http-usage.yaml
@@ -11,10 +11,15 @@ file:
       - json
       - js
 
+    matchers-condition: and
     matchers:
       - type: regex
         regex:
-          - "http://"
+          - "http://[^s]"
+      - type: regex  
+        regex: 
+          - "https://"
+        negative: true
 
     extractors:
       - type: regex
@@ -22,4 +27,3 @@ file:
         name: extracted_http_url
         regex:
           - "http://[^\\s'\"]+"
-


### PR DESCRIPTION
Changes:

- Use `matchers-condition: and` to require both an HTTP match and no HTTPS match
- Update the HTTP regex to exclude http:// in comments or strings 
- Add a negative HTTPS matcher to check HTTP is used without HTTPS

This makes the template more targeted by requiring HTTP usage without HTTPS to avoid false positives. The extractors stay the same.